### PR TITLE
Add GitHub Actions release workflow for binary distribution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,109 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version (e.g., v1.0.0)'
+        required: true
+        type: string
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  create-release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      
+      - name: Generate release notes
+        id: release-notes
+        run: |
+          # Get the latest tag (if any) or use the first commit
+          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || git rev-list --max-parents=0 HEAD)
+          
+          # Generate changelog from commits
+          echo "## Changes" > release_notes.md
+          echo "" >> release_notes.md
+          git log ${LAST_TAG}..HEAD --pretty=format:"- %s" --reverse >> release_notes.md
+      
+      - name: Create Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create ${{ github.event.inputs.version }} \
+            --title "${{ github.event.inputs.version }}" \
+            --notes-file release_notes.md
+
+  build:
+    name: Build ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    needs: create-release
+    permissions:
+      contents: write
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            suffix: ""
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+            suffix: ""
+          - os: macos-latest
+            target: x86_64-apple-darwin
+            suffix: ""
+          - os: macos-latest
+            target: aarch64-apple-darwin
+            suffix: ""
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            suffix: ".exe"
+
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Install Rust target
+        run: rustup target add ${{ matrix.target }}
+      
+      - name: Install musl tools
+        if: matrix.target == 'x86_64-unknown-linux-musl'
+        run: sudo apt-get install -y musl-tools
+      
+      - name: Build
+        run: cargo build --release --target ${{ matrix.target }}
+      
+      - name: Package binary
+        run: |
+          mkdir -p dist
+          if [ "${{ matrix.os }}" = "windows-latest" ]; then
+            cp target/${{ matrix.target }}/release/junit-rtgen${{ matrix.suffix }} dist/
+          else
+            cp target/${{ matrix.target }}/release/junit-rtgen dist/
+          fi
+          
+          # Create archive
+          cd dist
+          if [ "${{ matrix.os }}" = "windows-latest" ]; then
+            7z a ../junit-rtgen-${{ github.event.inputs.version }}-${{ matrix.target }}.zip junit-rtgen${{ matrix.suffix }}
+          else
+            tar czf ../junit-rtgen-${{ github.event.inputs.version }}-${{ matrix.target }}.tar.gz junit-rtgen
+          fi
+      
+      - name: Upload Release Asset
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          ASSET_PATH="./junit-rtgen-${{ github.event.inputs.version }}-${{ matrix.target }}"
+          if [ "${{ matrix.os }}" = "windows-latest" ]; then
+            ASSET_PATH="${ASSET_PATH}.zip"
+          else
+            ASSET_PATH="${ASSET_PATH}.tar.gz"
+          fi
+          gh release upload ${{ github.event.inputs.version }} "${ASSET_PATH}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,18 +21,18 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      
+
       - name: Generate release notes
         id: release-notes
         run: |
           # Get the latest tag (if any) or use the first commit
           LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || git rev-list --max-parents=0 HEAD)
-          
+
           # Generate changelog from commits
           echo "## Changes" > release_notes.md
           echo "" >> release_notes.md
           git log ${LAST_TAG}..HEAD --pretty=format:"- %s" --reverse >> release_notes.md
-      
+
       - name: Create Release
         env:
           GH_TOKEN: ${{ github.token }}
@@ -68,17 +68,17 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      
+
       - name: Install Rust target
         run: rustup target add ${{ matrix.target }}
-      
+
       - name: Install musl tools
         if: matrix.target == 'x86_64-unknown-linux-musl'
         run: sudo apt-get install -y musl-tools
-      
+
       - name: Build
         run: cargo build --release --target ${{ matrix.target }}
-      
+
       - name: Package binary
         run: |
           mkdir -p dist
@@ -87,7 +87,7 @@ jobs:
           else
             cp target/${{ matrix.target }}/release/junit-rtgen dist/
           fi
-          
+
           # Create archive
           cd dist
           if [ "${{ matrix.os }}" = "windows-latest" ]; then
@@ -95,7 +95,7 @@ jobs:
           else
             tar czf ../junit-rtgen-${{ github.event.inputs.version }}-${{ matrix.target }}.tar.gz junit-rtgen
           fi
-      
+
       - name: Upload Release Asset
         env:
           GH_TOKEN: ${{ github.token }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,8 +77,20 @@ The project is structured as a Rust library with CLI wrapper, implementing dual 
 
 ## CI/CD
 
-GitHub Actions workflow (`.github/workflows/rust.yml`) runs on push to main and pull requests:
+### Continuous Integration (`.github/workflows/rust.yml`)
+Runs on push to main and pull requests:
 - Runs `cargo check` to verify compilation
 - Runs `cargo fmt --all -- --check` to ensure consistent formatting
 - Runs `cargo clippy --all-targets --all-features -- -D warnings` to catch code issues
 - Runs `cargo test` to execute all tests
+
+### Release Process (`.github/workflows/release.yml`)
+Manual release workflow triggered via GitHub Actions `workflow_dispatch`:
+- Input: Release version (e.g., `v1.0.0`)
+- Generates release notes from commit history since last tag
+- Builds binaries for multiple platforms:
+  - Linux (x86_64-unknown-linux-gnu, x86_64-unknown-linux-musl)
+  - macOS (x86_64-apple-darwin, aarch64-apple-darwin)
+  - Windows (x86_64-pc-windows-msvc)
+- Creates GitHub release with downloadable binary archives
+- No crates.io publishing (binaries-only distribution)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,7 +86,14 @@ Runs on push to main and pull requests:
 
 ### Release Process (`.github/workflows/release.yml`)
 Manual release workflow triggered via GitHub Actions `workflow_dispatch`:
-- Input: Release version (e.g., `v1.0.0`)
+
+**Steps to create a release:**
+1. Update `version` in `Cargo.toml` (e.g., `"1.0.0"`)
+2. Commit and push: `git commit -am "Bump version to 1.0.0" && git push`
+3. Go to GitHub Actions → "Release" workflow → "Run workflow"
+4. Enter version tag (e.g., `v1.0.0`) and run
+
+**Workflow automatically:**
 - Generates release notes from commit history since last tag
 - Builds binaries for multiple platforms:
   - Linux (x86_64-unknown-linux-gnu, x86_64-unknown-linux-musl)

--- a/README.md
+++ b/README.md
@@ -104,6 +104,33 @@ cargo clippy
 cargo run < sample.xml
 ```
 
+## Release Process
+
+To create a new release:
+
+1. **Update version in `Cargo.toml`**:
+   ```toml
+   version = "1.0.0"
+   ```
+
+2. **Commit and push the version change**:
+   ```bash
+   git commit -am "Bump version to 1.0.0"
+   git push
+   ```
+
+3. **Trigger the release workflow**:
+   - Go to [GitHub Actions](https://github.com/smartbank-inc/junit-rtgen/actions)
+   - Select "Release" workflow
+   - Click "Run workflow"
+   - Enter version (e.g., `v1.0.0`)
+   - Click "Run workflow"
+
+The workflow will automatically:
+- Generate release notes from recent commits
+- Build binaries for all supported platforms
+- Create a GitHub release with downloadable assets
+
 ## License
 
 MIT License (see LICENSE file)

--- a/README.md
+++ b/README.md
@@ -13,6 +13,26 @@ A CLI tool that converts JUnit XML format files to ParallelTests::RSpec::Runtime
 
 ## Installation
 
+### Download Pre-built Binaries (Recommended)
+
+Download the latest release for your platform from the [GitHub Releases](https://github.com/smartbank-inc/junit-rtgen/releases) page:
+
+- **Linux (x86_64)**: `junit-rtgen-vX.X.X-x86_64-unknown-linux-gnu.tar.gz`
+- **Linux (musl)**: `junit-rtgen-vX.X.X-x86_64-unknown-linux-musl.tar.gz`
+- **macOS (Intel)**: `junit-rtgen-vX.X.X-x86_64-apple-darwin.tar.gz`
+- **macOS (Apple Silicon)**: `junit-rtgen-vX.X.X-aarch64-apple-darwin.tar.gz`
+- **Windows**: `junit-rtgen-vX.X.X-x86_64-pc-windows-msvc.zip`
+
+```bash
+# Example for Linux
+curl -LO https://github.com/smartbank-inc/junit-rtgen/releases/latest/download/junit-rtgen-v1.0.0-x86_64-unknown-linux-gnu.tar.gz
+tar xzf junit-rtgen-v1.0.0-x86_64-unknown-linux-gnu.tar.gz
+chmod +x junit-rtgen
+sudo mv junit-rtgen /usr/local/bin/
+```
+
+### Build from Source
+
 ```bash
 # Clone the repository
 git clone https://github.com/smartbank-inc/junit-rtgen.git


### PR DESCRIPTION
- Add manual release workflow with workflow_dispatch trigger
- Build cross-platform binaries (Linux, macOS, Windows)
- Generate release notes from commit history
- Use modern GitHub CLI for release creation and asset uploads
- Add job-level permissions for security
- Update README with binary installation instructions
- Update CLAUDE.md with release process documentation

🤖 Generated with [Claude Code](https://claude.ai/code)